### PR TITLE
Implement SeoMetadata variant creation

### DIFF
--- a/eBlog.API/Controllers/SeoMetadataController.cs
+++ b/eBlog.API/Controllers/SeoMetadataController.cs
@@ -36,6 +36,11 @@ namespace eBlog.API.Controllers
             var deleted = await _service.DeleteAsync(id);
             return deleted.Success ? NoContent() : NotFound();
         }
+
+        [HttpPost("{canonicalId:guid}/variants")]
+        public async Task<IActionResult> AddVariant(Guid canonicalId, [FromBody] SeoMetadataCreateDto dto)
+            => Ok(await _service.AddVariantAsync(canonicalId, dto));
+
         [HttpGet("{postId}/variants")]
         public async Task<IActionResult> GetSeoVariantsByPost(Guid postId)
         {

--- a/eBlog.Application/DTOs/SeoMetadataDto.cs
+++ b/eBlog.Application/DTOs/SeoMetadataDto.cs
@@ -3,6 +3,7 @@
     public class SeoMetadataDto
     {
         public Guid Id { get; set; }
+        public Guid CanonicalGroupId { get; set; }
         public string MetaTitle { get; set; } = null!;
         public string MetaDescription { get; set; } = null!;
         public string? MetaKeywords { get; set; }
@@ -11,6 +12,7 @@
         public string? OpenGraphDescription { get; set; }
         public string? OpenGraphImage { get; set; }
         public string? StructuredDataJson { get; set; }
+        public string LanguageCode { get; set; } = "tr";
     }
     public class SeoMetadataCreateDto
     {
@@ -22,6 +24,7 @@
         public string? OpenGraphDescription { get; set; }
         public string? OpenGraphImage { get; set; }
         public string? StructuredDataJson { get; set; }
+        public string LanguageCode { get; set; } = "tr";
     }
     public class SeoMetadataUpdateDto
     {
@@ -33,6 +36,7 @@
         public string? OpenGraphDescription { get; set; }
         public string? OpenGraphImage { get; set; }
         public string? StructuredDataJson { get; set; }
+        public string LanguageCode { get; set; } = "tr";
     }
 
 }

--- a/eBlog.Application/Interfaces/ISeoMetadataService.cs
+++ b/eBlog.Application/Interfaces/ISeoMetadataService.cs
@@ -1,11 +1,13 @@
 ﻿using eBlog.Application.DTOs;
 using eBlog.Domain.Entities;
+using eBlog.Shared.Results;
 
 namespace eBlog.Application.Interfaces
 {
     public interface ISeoMetadataService : IGenericService<SeoMetadata, SeoMetadataDto, SeoMetadataCreateDto, SeoMetadataUpdateDto>
     {
         Task<List<SeoMetadataDto>> GetVariantsByPostIdAsync(Guid postId);
+        Task<IDataResult<SeoMetadataDto>> AddVariantAsync(Guid canonicalSeoId, SeoMetadataCreateDto dto);
     }
 
 }

--- a/eBlog.Application/Services/SeoMetadataService.cs
+++ b/eBlog.Application/Services/SeoMetadataService.cs
@@ -3,6 +3,7 @@ using eBlog.Application.DTOs;
 using eBlog.Application.Interfaces;
 using eBlog.Domain.Entities;
 using eBlog.Domain.Interfaces;
+using eBlog.Shared.Results;
 
 namespace eBlog.Application.Services
 {
@@ -22,6 +23,46 @@ namespace eBlog.Application.Services
             _repository = repository;
             _mapper = mapper;
             _postRepository = postRepository;
+        }
+
+        public override async Task<IDataResult<SeoMetadataDto>> AddAsync(SeoMetadataCreateDto dto)
+        {
+            try
+            {
+                var entity = _mapper.Map<SeoMetadata>(dto);
+                entity.CanonicalGroupId = Guid.NewGuid();
+                await _repository.AddAsync(entity);
+                await _unitOfWork.SaveChangesAsync();
+                var resultDto = _mapper.Map<SeoMetadataDto>(entity);
+                return new SuccessDataResult<SeoMetadataDto>(resultDto, "Başarıyla eklendi.");
+            }
+            catch (Exception ex)
+            {
+                return new ErrorDataResult<SeoMetadataDto>("Ekleme sırasında hata oluştu: " + ex.Message);
+            }
+        }
+
+        public async Task<IDataResult<SeoMetadataDto>> AddVariantAsync(Guid canonicalSeoId, SeoMetadataCreateDto dto)
+        {
+            try
+            {
+                var canonical = await _repository.GetByIdAsync(canonicalSeoId);
+                if (canonical == null)
+                    return new ErrorDataResult<SeoMetadataDto>("Seo kaydı bulunamadı.");
+
+                var entity = _mapper.Map<SeoMetadata>(dto);
+                entity.CanonicalGroupId = canonical.CanonicalGroupId;
+
+                await _repository.AddAsync(entity);
+                await _unitOfWork.SaveChangesAsync();
+
+                var resultDto = _mapper.Map<SeoMetadataDto>(entity);
+                return new SuccessDataResult<SeoMetadataDto>(resultDto);
+            }
+            catch (Exception ex)
+            {
+                return new ErrorDataResult<SeoMetadataDto>("Varyant eklenirken hata oluştu: " + ex.Message);
+            }
         }
 
         public async Task<List<SeoMetadataDto>> GetVariantsByPostIdAsync(Guid postId)


### PR DESCRIPTION
## Summary
- expose language and canonical group info on `SeoMetadataDto`
- allow adding seo metadata variants through service and controller
- create canonical group IDs automatically when adding SeoMetadata

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c08b01c3c83339cd80c1b3c563150